### PR TITLE
feat: add riscv64 support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,6 +23,7 @@ platforms:
   arm64:
   armhf:
   ppc64el:
+  riscv64:
   s390x:
 
 apps:

--- a/spread.yaml
+++ b/spread.yaml
@@ -14,4 +14,4 @@ suites:
 prepare: |
   set -ex
   # install gradle snap
-  snap install --dangerous --classic gradle_*_amd64.snap
+  snap install --dangerous --classic gradle_*_$(dpkg --print-architecture).snap

--- a/tests/spread/variables/task.yaml
+++ b/tests/spread/variables/task.yaml
@@ -3,6 +3,8 @@ summary: Check that snap environment variables work
 execute: |
   set -ex
 
+  export SPREAD_TEST_ARCH=$(dpkg --print-architecture)
+
   gradle -q printUserHome | grep "Gradle User Home: /home/root/.gradle"
   export GRADLE_USER_HOME=/home/root/test
   gradle -q printUserHome | grep "Gradle User Home: /home/root/test"
@@ -10,5 +12,5 @@ execute: |
   # install additional openjdk to check the launchers
   apt-get update && apt-get install -y openjdk-17-jdk-headless
   gradle -version | grep "Launcher JVM:  21.0."
-  export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64/
+  export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-${SPREAD_TEST_ARCH}/
   gradle -version | grep "Launcher JVM:  17.0."


### PR DESCRIPTION
This enables riscv64 support for the gradle snap. The spread tests pass on an Ubuntu 24.04 RISC-V machine, and I will shortly test it with the craft-parts test suite as well.

Fixes #63 